### PR TITLE
Target java 8 compatability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ allprojects {
     plugins.withType<JavaPlugin> {
         configure<JavaPluginExtension> {
             sourceCompatibility = JavaVersion.VERSION_11
-            targetCompatibility = JavaVersion.VERSION_11
+            targetCompatibility = JavaVersion.VERSION_1_8
             withJavadocJar()
             withSourcesJar()
         }


### PR DESCRIPTION
Java 8 is the only JRE so any jarred applications and all their dependencies are required to target 8 as a maximum.

https://www.java.com/download/why-java-8-recommended.html