### PR TITLE
feat: teleport handler

### DIFF
--- a/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/handlers/TeleportHandler.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/handlers/TeleportHandler.kt
@@ -1,0 +1,34 @@
+package org.rsmod.api.net.rsprot.handlers
+
+import jakarta.inject.Inject
+import net.rsprot.protocol.game.incoming.misc.user.Teleport
+import org.rsmod.api.config.refs.modlevels
+import org.rsmod.api.net.rsprot.player.protectedTelejump
+import org.rsmod.api.player.output.clearMapFlag
+import org.rsmod.api.player.protect.clearPendingAction
+import org.rsmod.api.realm.Realm
+import org.rsmod.events.EventBus
+import org.rsmod.game.entity.Player
+import org.rsmod.map.CoordGrid
+import org.rsmod.routefinder.collision.CollisionFlagMap
+
+class TeleportHandler
+@Inject
+constructor(
+    private val realm: Realm,
+    private val eventBus: EventBus,
+    private val collision: CollisionFlagMap,
+) : MessageHandler<Teleport> {
+    override fun handle(player: Player, message: Teleport) {
+        if (player.isDelayed) {
+            player.clearMapFlag()
+            return
+        }
+        val dest = CoordGrid(message.x, message.z, player.level)
+        player.clearPendingAction(eventBus)
+        player.resetFaceEntity()
+        if (player.modLevel.hasAccessTo(modlevels.admin)) {
+            player.protectedTelejump(collision, dest)
+        }
+    }
+}

--- a/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/provider/MessageConsumerProvider.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/provider/MessageConsumerProvider.kt
@@ -16,6 +16,7 @@ import net.rsprot.protocol.game.incoming.misc.user.ClientCheat
 import net.rsprot.protocol.game.incoming.misc.user.CloseModal
 import net.rsprot.protocol.game.incoming.misc.user.MoveGameClick
 import net.rsprot.protocol.game.incoming.misc.user.MoveMinimapClick
+import net.rsprot.protocol.game.incoming.misc.user.Teleport
 import net.rsprot.protocol.game.incoming.npcs.OpNpc
 import net.rsprot.protocol.game.incoming.npcs.OpNpc6
 import net.rsprot.protocol.game.incoming.npcs.OpNpcT
@@ -54,6 +55,7 @@ import org.rsmod.api.net.rsprot.handlers.ResumePNameDialogHandler
 import org.rsmod.api.net.rsprot.handlers.ResumePObjDialogHandler
 import org.rsmod.api.net.rsprot.handlers.ResumePStringDialogHandler
 import org.rsmod.api.net.rsprot.handlers.ResumePauseButtonHandler
+import org.rsmod.api.net.rsprot.handlers.TeleportHandler
 import org.rsmod.api.net.rsprot.handlers.WindowStatusHandler
 import org.rsmod.game.entity.Player
 
@@ -86,6 +88,7 @@ constructor(
     private val ifButtonD: IfButtonDHandler,
     private val ifButtonT: IfButtonTHandler,
     private val mapBuildComplete: MapBuildCompleteHandler,
+    private val teleport: TeleportHandler,
 ) {
     fun get(): DefaultGameMessageConsumerRepositoryProvider<Player> {
         val builder = GameMessageConsumerRepositoryBuilder<Player>()
@@ -114,6 +117,7 @@ constructor(
         builder.addListener(IfButtonD::class.java, ifButtonD)
         builder.addListener(IfButtonT::class.java, ifButtonT)
         builder.addListener(MapBuildComplete::class.java, mapBuildComplete)
+        builder.addListener(Teleport::class.java, teleport)
         return DefaultGameMessageConsumerRepositoryProvider(builder.build())
     }
 }


### PR DESCRIPTION
Adds missing packet handling from incoming client packet. Example use case: World map ctrl shift click.